### PR TITLE
Fix Footer brand name, update sitemap and robots for completeness

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/admin/", "/api/"],
+        disallow: ["/admin/", "/api/", "/checkout/", "/mypage/", "/login/"],
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -59,6 +59,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "yearly",
       priority: 0.3,
     },
+    {
+      url: `${baseUrl}/products`,
+      lastModified: new Date("2026-03-10"),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/premium`,
+      lastModified: new Date("2026-03-10"),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
   ];
 
   const featurePages: MetadataRoute.Sitemap = features.map((slug) => ({

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,8 +8,8 @@ export default function Footer() {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Brand */}
           <div className="md:col-span-1">
-            <Link href="/" className="text-xl font-bold">
-              <span className="text-accent">futa</span><span className="text-white">tabito</span>
+            <Link href="/" className="text-xl font-bold tracking-tight">
+              <span className="text-[#c9a96e]">futa</span><span className="text-white">tabito</span>
             </Link>
             <p className="mt-2 text-sm text-white/70">
               全国10都市対応のデートプランAI

--- a/tasks/evaluation.md
+++ b/tasks/evaluation.md
@@ -117,3 +117,4 @@
 | 2026-03-16 | PR #181 特集3件追加（北新地・栄・目黒川お花見）、プラン結果の印刷機能追加（@media print） | UX・マネタイズ品質向上（スコア現状維持） |
 | 2026-03-16 | PR #183 パフォーマンス・品質・UX改善（画像AVIF/WebP最適化、React.lazy遅延読み込み、スケルトンローディングUI、プログレスバー付きローディング、アクセシビリティ改善、prefers-reduced-motion対応、CSS最適化） | UX・管理運用品質向上（スコア現状維持） |
 | 2026-03-16 | PR #185 エラーハンドリング強化（カスタム404ページ、ErrorBoundaryコンポーネント、エラーページ、テスト12件追加） | UX品質向上（スコア現状維持） |
+| 2026-03-16 | Footer.tsxブランド名修正（gold "futa" + white "tabito" のダークモード対応）、sitemap.ts に /products・/premium 追加、robots.ts に /checkout・/mypage・/login の disallow 追加 | 管理・運用品質向上（スコア現状維持） |


### PR DESCRIPTION
- Footer: use hardcoded gold (#c9a96e) for "futa" to ensure visibility in both light and dark modes, add tracking-tight to match Header
- sitemap.ts: add /products and /premium pages
- robots.ts: disallow /checkout/, /mypage/, /login/ (private pages)
- evaluation.md: add changelog entry

https://claude.ai/code/session_0179S3dcy3duFi2CnGqNCbzs